### PR TITLE
Fix bug where submitting word before playing word would generate invalid state

### DIFF
--- a/assets/scripts/practice.js
+++ b/assets/scripts/practice.js
@@ -139,6 +139,9 @@ function guessPreprocess() {
     } else if (attemptStr == '') {
         console.log("Empty string submitted as guess. Ignoring that.");
         return;
+    } else if (activePlayer == null) {
+        console.log("Sound has not yet been played. You shouldn't submit anything.");
+        return;
     } else {
         checkGuess();
     }


### PR DESCRIPTION
As raised in #2 if the player was not triggered before submitting a non-empty word, no update is visible (because the internal null reference), but the result is handled as if wrong (or right, if cheating, or very, very lucky)

This change fixes this, by checking if active player is assigned, and if not, skipping the submit.