### PR TITLE
Fix copy results button

### DIFF
--- a/assets/scripts/results.js
+++ b/assets/scripts/results.js
@@ -7,9 +7,10 @@ const results = document.querySelector("#results");
 const copyBtn = document.querySelector("#copy-btn")
 const typos = document.querySelector("#typos")
 
-copyBtn.addEventListener("click", (e) => {
+copyBtn.addEventListener("click", async (e) => {
+    e.preventDefault();
     shareableResults = `Spellcheck #${puzzleNum}\n${sessionStorage.getItem('emojiResults').replaceAll("\\n", "\n").replaceAll(" ", "")}`;
-    navigator.clipboard.writeText(shareableResults);
+    await navigator.clipboard.writeText(shareableResults);
 }) 
 
 if (emojiResults != null){


### PR DESCRIPTION
This fixes the copy results button which wasn't working due to the following issues:
1. It was refreshing the page before it could copy due to the event listener default behavior
2. The `writeText` function was not being awaited