### PR TITLE
add keybinds for audio and next round

### DIFF
--- a/assets/scripts/keyboard.js
+++ b/assets/scripts/keyboard.js
@@ -381,6 +381,36 @@ document.addEventListener("keyup", (e) => {
    let pressedKey = String(e.key)
    let found = pressedKey.match(/[a-z]/gi)
 
+    if (pressedKey === "1" || pressedKey === 'Numpad1') {
+        wordOne.dispatchEvent(new Event("click"));
+        return;
+    }
+
+    if (pressedKey === "2" || pressedKey === 'Numpad2') {
+        wordTwo.dispatchEvent(new Event("click"));
+        return;
+    }
+
+    if (pressedKey === "3" || pressedKey === 'Numpad3') {
+        wordThree.dispatchEvent(new Event("click"));
+        return;
+    }
+
+    if (pressedKey === "4" || pressedKey === 'Numpad4') {
+        wordFour.dispatchEvent(new Event("click"));
+        return;
+    }
+
+    if (pressedKey === "5" || pressedKey === 'Numpad5') {
+        wordFive.dispatchEvent(new Event("click"));
+        return;
+    }
+
+    if (pressedKey === "ArrowRight" && numSubmitted === 5) {
+        nextRoundBtn.dispatchEvent(new Event("click"));
+        return;
+    }
+
     if (pressedKey === "Enter") {
         document.querySelector(`#${pressedKey}`).classList.add("clicked")
         setTimeout(() => {


### PR DESCRIPTION
Feature for #25: number/numpad keys 1-5 dispatch events for playing audio. When next round is available, you can use the right arrow key to go to the next round.